### PR TITLE
Timing improvements

### DIFF
--- a/pepperl_fuchs_r2000/include/pepperl_fuchs_r2000/http_command_interface.h
+++ b/pepperl_fuchs_r2000/include/pepperl_fuchs_r2000/http_command_interface.h
@@ -100,6 +100,12 @@ private:
     //! @returns The HTTP status code or 0 in case of an error
     int httpGet(const std::string request_path, std::string& header, std::string& content);
 
+    //! Send a sensor specific HTTP-Command, returning parse tree (so as to be thread-safe-ish)
+    //! @param cmd command name
+    //! @param keys_values parameter->value map, which is encoded in the GET-request: ?p1=v1&p2=v2
+    //! @param resp_pt property tree representing the JSON data of the response
+    bool sendHttpCommand(const std::string cmd, const std::map< std::string, std::string > param_values, boost::property_tree::ptree & resp_pt );
+
     //! Send a sensor specific HTTP-Command
     //! @param cmd command name
     //! @param keys_values parameter->value map, which is encoded in the GET-request: ?p1=v1&p2=v2
@@ -110,6 +116,11 @@ private:
     //! @param param Parameter
     //! @param value Value
     bool sendHttpCommand(const std::string cmd, const std::string param = "", const std::string value = "" );
+
+    //! Check the error code and text of the given JSON
+    //! @param pt JSON property tree
+    //! @returns False in case of an error, True otherwise
+    static bool checkErrorCode(boost::property_tree::ptree pt);
 
     //! Check the error code and text of the returned JSON by the last request
     //! @returns False in case of an error, True otherwise
@@ -123,9 +134,6 @@ private:
 
     //! Returned JSON as property_tree
     boost::property_tree::ptree pt_;
-
-    //! HTTP-Status code of last request
-    int http_status_code_;
 
 };
 }

--- a/pepperl_fuchs_r2000/include/pepperl_fuchs_r2000/r2000_driver.h
+++ b/pepperl_fuchs_r2000/include/pepperl_fuchs_r2000/r2000_driver.h
@@ -33,6 +33,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <thread>
 #include <boost/optional.hpp>
 #include <pepperl_fuchs_r2000/protocol_info.h>
 #include <pepperl_fuchs_r2000/packet_structure.h>
@@ -136,7 +137,9 @@ public:
     bool setParameter( const std::string& name, const std::string& value );
 
     //! Feed the watchdog with the current handle ID, to keep the data connection alive
-    void feedWatchdog(bool feed_always = false);
+    //! @param feed_always force feed the watchdog even if it's not hungry (neglect time since last feeding)
+    //! @param use_thread feed the wathdog in a separate thread for the purpose to avoid blocking the current thread
+    void feedWatchdog(bool feed_always = false, bool use_thread = true);
 
 private:
     //! HTTP/JSON interface of the scanner
@@ -156,6 +159,15 @@ private:
 
     //! Feeding interval (in seconds)
     double food_timeout_;
+
+    //! Thread object for watchdog feeding thread
+    std::thread watchdog_thread_;
+
+    //! Function for watchdog feeding thread
+    void watchdogTask();
+
+    //! Communication between the main thread and watchdog thread
+    bool watchdog_do_now_ = false;
 
     //! Handle information about data connection
     boost::optional<HandleInfo> handle_info_;


### PR DESCRIPTION
- feed R2000 watchdog in a thread (for more consistent timing in main data thread)
- return scans immediately when we receive the last packet (instead of waiting for first packet of next scan)

This should fix #1 and #2.  These changes have already been reflected in the git submodule for our app, but I wanted to put in a pull request to highlight them here, since they haven't been super-super rigorously tested.